### PR TITLE
Fixed plugin crashing the app on detaching from Activity

### DIFF
--- a/android/src/main/kotlin/com/cometchat/flutter_chat_ui_kit/FlutterChatUiKitPlugin.kt
+++ b/android/src/main/kotlin/com/cometchat/flutter_chat_ui_kit/FlutterChatUiKitPlugin.kt
@@ -219,15 +219,15 @@ class FlutterChatUiKitPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, P
   }
 
   override fun onDetachedFromActivityForConfigChanges() {
-    TODO("Not yet implemented")
+    // TODO("Not yet implemented")
   }
 
   override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-    TODO("Not yet implemented")
+    // TODO("Not yet implemented")
   }
 
   override fun onDetachedFromActivity() {
-    TODO("Not yet implemented")
+    // TODO("Not yet implemented")
   }
 
 //  private fun playDefaultSound(call: MethodCall, result: Result) {


### PR DESCRIPTION
Crashing TODOs are left in implementations which lead to app crash when the plugin tries to detach from Activity.

This goes unnoticed in the development and testing cycles as most of the times the plugin only needs to get detached when the app is being killed.

**References:** 
https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-t-o-d-o.html
https://api.flutter.dev/javadoc/io/flutter/embedding/engine/plugins/activity/ActivityAware.html#onDetachedFromActivity()

**How I found this issue?**
My team is working on a CometChat feature and found hundreds of fatal crashes on Firebase Crashlytics even though everything seemed alright. Here's the stack trace:

```csharp
Fatal Exception: cm.l: An operation is not implemented: Not yet implemented
   at com.cometchat.flutter_chat_ui_kit.FlutterChatUiKitPlugin.onDetachedFromActivity(FlutterChatUiKitPlugin.kt:230 undefined)
   at io.flutter.embedding.engine.FlutterEngineConnectionRegistry.detachFromActivity(FlutterEngineConnectionRegistry.java:385 undefined)
   at io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.onDetach(FlutterActivityAndFragmentDelegate.java:690 undefined)
   at io.flutter.embedding.android.FlutterActivity.onDestroy(FlutterActivity.java:762 undefined)
   at android.app.Activity.performDestroy(Activity.java:8406 undefined)
   at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1378 undefined)
   at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5640 undefined)
   at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5686 undefined)
   at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:47 undefined)
   at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45 undefined)
   at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176 undefined)
   at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97 undefined)
   at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2374 undefined)
   at android.os.Handler.dispatchMessage(Handler.java:106 undefined)
   at android.os.Looper.loopOnce(Looper.java:233 undefined)
   at android.os.Looper.loop(Looper.java:344 undefined)
   at android.app.ActivityThread.main(ActivityThread.java:8248 undefined)
   at java.lang.reflect.Method.invoke(Method.java undefined)
   at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:589 undefined)
   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1071 undefined)
```